### PR TITLE
0.7.1

### DIFF
--- a/petal/changelog.txt
+++ b/petal/changelog.txt
@@ -91,3 +91,8 @@ Since the last documented update:
 + Reaction-based UI menus for choices n stuff
 + Implemented basic type checking for --options
 * Various spelling fixes, removal of many line-end whitespaces
+
+[v0.7.1] (2018-04-07)
+* Fixed a mistake where !wlme would look for a config option as an attribute of Config, rather than going through Config.get()
+* Fixed an oversight wherein a failure to send a notification DM would not be correctly reported
++ Added flag --nosend to !wlaccept to prevent sending DM notification

--- a/petal/commands/minecraft/mc_mod.py
+++ b/petal/commands/minecraft/mc_mod.py
@@ -9,12 +9,16 @@ from petal.commands.minecraft import auth
 class CommandsMCMod(auth.CommandsMCAuth):
     op = 3
 
-    async def cmd_wlaccept(self, args, src, **_):
+    async def cmd_wlaccept(self, args, src, _nosend=False, **_):
         """Mark a PlayerDB entry as "approved", to be added to the whitelist.
 
-        Same methods of specification as {p}WLQuery; See `{p}help wlquery` for more information.
+        If this is the first time the user is being approved, unless `--nosend` is passed, a DM will be sent to the user, if possible, to notify them that their application has been accepted.
+
+        Same methods of specification as `{p}wlquery`; See `{p}help wlquery` for more information.
 
         Syntax: `{p}wlaccept <profile_identifier>`
+
+        Options: `--nosend` :: Do not send a message to the user telling them they have been whitelisted.
         """
         if not args:
             return
@@ -30,7 +34,7 @@ class CommandsMCMod(auth.CommandsMCAuth):
                 "wl+",
                 f"{src.author.name}#{src.author.discriminator} ({src.author.id}) sets APPROVED on '{mcname}'",
             )
-            if doSend:
+            if doSend and not _nosend:
                 recipientobj = self.client.get_server(
                     self.config.get("mainServer")
                 ).get_member(recipientid)

--- a/petal/commands/minecraft/mc_mod.py
+++ b/petal/commands/minecraft/mc_mod.py
@@ -36,14 +36,16 @@ class CommandsMCMod(auth.CommandsMCAuth):
                 ).get_member(recipientid)
                 try:
                     wlpm = "You have been whitelisted on the Patch Minecraft server :D Remember that the IP is `minecraft.patchgaming.org`, and note that it may take up to 60 seconds to take effect"
-                    await self.client.send_message(channel=recipientobj, message=wlpm)
+                    msg = await self.client.send_message(channel=recipientobj, message=wlpm)
                 except discord.DiscordException as e:
                     self.log.err("Error on WLAdd PM: " + str(e))
-                    return "You have approved `{}` for <@{}>...But a PM could not be sent D:".format(
+                    msg = None
+                if msg:
+                    return "You have successfully approved `{}` for <@{}> and a notification PM has been sent :D".format(
                         mcname, recipientid
                     )
                 else:
-                    return "You have successfully approved `{}` for <@{}> and a notification PM has been sent :D".format(
+                    return "You have approved `{}` for <@{}>...But a PM could not be sent D:".format(
                         mcname, recipientid
                     )
             else:

--- a/petal/commands/minecraft/mc_public.py
+++ b/petal/commands/minecraft/mc_public.py
@@ -30,7 +30,7 @@ class CommandsMCPublic(auth.CommandsMCAuth):
             )
 
             wlreq = await self.client.send_message(
-                channel=self.config.mc_channel, message="`<request loading...>`"
+                channel=self.config.get("mc_channel"), message="`<request loading...>`"
             )
 
             await self.client.edit_message(

--- a/version_info.sh
+++ b/version_info.sh
@@ -3,11 +3,11 @@
 # Not necessarily the prettiest but easy to work with.
 
 # MATCH THIS TO THE VERSION IN PETAL
-VERSION=0.7.0
+VERSION=0.7.1
 
 #(optional) what the webhook message should say.
 UPDATE_TITLE="Preparing to Prepare"
 
 # Separate bullet points with hyphens and use \n characters please.
-CHANGELOG="A primarily administrative update, and maybe some features\n+ Filled out changelog.txt\n*!statsfornerds to !stats\n*!list_connected_servers to !servers\n+ !define command\n+ !info command\n+ Added rudimentary type-checking for --options"
+CHANGELOG="* Fixed a mistake where !wlme would look for a config option as an attribute of Config, rather than going through Config.get()\n* Fixed an oversight wherein a failure to send a notification DM would not be correctly reported\n+ Added flag --nosend to !wlaccept to prevent sending DM notification"
 


### PR DESCRIPTION
* Fixed a mistake where !wlme would look for a config option as an attribute of Config, rather than going through Config.get()
* Fixed an oversight wherein a failure to send a notification DM would not be correctly reported
+ Added flag --nosend to !wlaccept to prevent sending DM notification